### PR TITLE
Click Dependency Fix

### DIFF
--- a/configs/.pre-commit-config.yaml
+++ b/configs/.pre-commit-config.yaml
@@ -6,7 +6,8 @@ repos:
   - id: end-of-file-fixer
   - id: trailing-whitespace
 - repo: https://github.com/psf/black
-  rev: 19.3b0
+  rev: 22.3.0
+  additional_dependencies: ['click>=8.1.2']
   hooks:
   - id: black
 - repo: https://github.com/asottile/reorder_python_imports

--- a/setup.sh
+++ b/setup.sh
@@ -23,4 +23,4 @@ apt-get -y install autoconf bison build-essential libssl-dev libyaml-dev \
 
 # python & pip install
 apt-get -y install python3-pip
-pip3 install pre-commit==2.3.0
+pip3 install pre-commit==2.19.0


### PR DESCRIPTION
This PR adds a fix to a dependency issue with `Black` and `Click`...

Based on my research and testing, the issue is fixed with a bump to later versions of the packages.

`Black==22.3.0`
`Click==2.19.0`

Type: #patch